### PR TITLE
update endpoint canister

### DIFF
--- a/examples/endpoint.did
+++ b/examples/endpoint.did
@@ -6,6 +6,7 @@ type HttpResponse = record {
 };
 type Result = variant { Ok : text; Err : text };
 type RpcCallArgs = record {
+  url : opt text;
   max_response_bytes : opt nat64;
   body : text;
   cycles : opt nat64;
@@ -15,6 +16,7 @@ type TransformArgs = record { context : vec nat8; response : HttpResponse };
 service : (text, text) -> {
   getInfo : () -> (State) query;
   rpcCall : (RpcCallArgs) -> (Result);
+  rpcCallPrivate : (RpcCallArgs) -> (Result);
   setAPIKey : (text) -> (bool);
   setUrl : (text) -> (bool);
   transform : (TransformArgs) -> (HttpResponse) query;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -63,6 +63,11 @@ impl<T: Transport> Web3<T> {
         &self.transport
     }
 
+    /// set the max response bytes
+    pub fn set_max_response_bytes(&mut self, bytes: u64) {
+        self.transport.set_max_response_bytes(bytes)
+    }
+
     /// Access methods from custom namespace
     pub fn api<A: Namespace<T>>(&self) -> A {
         A::new(self.transport.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ pub trait Transport: std::fmt::Debug + Clone {
         let (id, request) = self.prepare(method, params);
         self.send(id, request)
     }
+
+    /// set the max response bytes, do nothing by default
+    fn set_max_response_bytes(&mut self, bytes: u64) {}
 }
 
 /// A transport implementation supporting batch requests.

--- a/src/transports/batch.rs
+++ b/src/transports/batch.rs
@@ -79,6 +79,10 @@ where
 
         SingleResult(rx)
     }
+
+    fn set_max_response_bytes(&mut self, v: u64) {
+        self.transport.set_max_response_bytes(v);
+    }
 }
 
 /// Result of calling a single method that will be part of the batch.

--- a/src/transports/either.rs
+++ b/src/transports/either.rs
@@ -42,6 +42,13 @@ where
             Self::Right(ref b) => b.send(id, request).boxed(),
         }
     }
+
+    fn set_max_response_bytes(&mut self, v: u64) {
+        match *self {
+            Self::Left(ref mut a) => a.set_max_response_bytes(v),
+            Self::Right(ref mut b) => b.set_max_response_bytes(v),
+        }
+    }
 }
 
 impl<A, B, ABatch, BBatch> BatchTransport for Either<A, B>

--- a/src/transports/ic_http.rs
+++ b/src/transports/ic_http.rs
@@ -51,10 +51,6 @@ impl ICHttp {
         )
     }
 
-    pub fn set_max_response_bytes(&mut self, v: u64) {
-        self.client.set_max_response_bytes(v);
-    }
-
     pub fn set_cycles_per_call(&mut self, v: u64) {
         self.client.set_cycles_per_call(v);
     }
@@ -100,6 +96,10 @@ impl Transport for ICHttp {
             let output: Output = execute_rpc(&client, url, &Request::Single(call), id).await?;
             helpers::to_result_from_output(output)
         })
+    }
+
+    fn set_max_response_bytes(&mut self, v: u64) {
+        self.client.set_max_response_bytes(v);
     }
 }
 


### PR DESCRIPTION
- add url in call arguments as optional parameter
- add `rpcCallPrivate` function, only owner can call this method
- public `rpcCall` must provide the url

- add `set_max_response_bytes` for `Transport` trait
- implement `set_max_response_bytes` for all transport implementation
- add `web3.set_max_response_bytes` function