### PR TITLE
charge cycles

### DIFF
--- a/examples/endpoint.rs
+++ b/examples/endpoint.rs
@@ -5,6 +5,9 @@ use ic_cdk::api::management_canister::http_request::{TransformArgs, HttpResponse
 use ic_cdk_macros::*;
 use ic_web3::{transports::ICHttp, Web3};
 
+// when the both request and response are max 2MB, the const of http calls is about 0.5T
+const MAX_CYCLES_REQUIRES: u128 = 500_000_000_000; // 0.5T
+
 #[derive(CandidType, Deserialize, Clone)]
 struct State {
     owner: Principal,
@@ -16,7 +19,6 @@ struct State {
 struct RpcCallArgs {
     url: Option<String>,
     max_response_bytes: Option<u64>,
-    cycles: Option<u64>,
     body: String,
 }
 
@@ -25,7 +27,7 @@ impl Default for State {
         Self { 
             owner: Principal::management_canister(), 
             url: Default::default(), 
-            api_key: Default::default() 
+            api_key: Default::default(),
         }
     }
 }
@@ -36,7 +38,7 @@ thread_local! {
 
 #[init]
 #[candid_method(init)]
-fn init(url: String, api_key: String) {
+fn init(url: String, api_key: String,) {
     let owner = ic_cdk::caller();
     STATE.with(|s| {
         let mut state = s.borrow_mut();
@@ -87,6 +89,7 @@ async fn set_api_key(api_key: String) -> bool {
 }
 
 /// rpcCallPrivate only owner can call
+/// private call will not charge cycles from caller
 #[update(name = "rpcCallPrivate", guard = "is_owner")]
 #[candid_method(update, rename = "rpcCallPrivate")]
 async fn rpc_call_private(args: RpcCallArgs) -> Result<String, String> {
@@ -102,7 +105,7 @@ async fn rpc_call_private(args: RpcCallArgs) -> Result<String, String> {
         format!("{}/{}", url.trim_matches(|x| x == '/' || char::is_whitespace(x)), api_key.trim())
     };
     
-    let w3 = match ICHttp::new(url_with_key.as_str(), args.max_response_bytes, args.cycles) {
+    let w3 = match ICHttp::new(url_with_key.as_str(), args.max_response_bytes, None) {
         Ok(v) => { Web3::new(v) },
         Err(e) => { return Err(e.to_string()) },
     };
@@ -115,9 +118,15 @@ async fn rpc_call_private(args: RpcCallArgs) -> Result<String, String> {
 }
 
 /// rpcCall anyone can call, but url must be provided
+/// accept max 0.5T cycles, the rest will be refunded
 #[update(name = "rpcCall")]
 #[candid_method(update, rename = "rpcCall")]
 async fn rpc_call(args: RpcCallArgs) -> Result<String, String> {
+    let cycles_call = ic_cdk::api::call::msg_cycles_available128();
+    if cycles_call < MAX_CYCLES_REQUIRES {
+        return Err(format!("requires {} cycles, get {} cycles", MAX_CYCLES_REQUIRES, cycles_call));
+    }
+   
     let url_with_key = if let Some(url) = args.url {
         // if url provided, use the url
         url
@@ -125,13 +134,20 @@ async fn rpc_call(args: RpcCallArgs) -> Result<String, String> {
         return Err("url must be provided".to_string())
     };
     
-    let w3 = match ICHttp::new(url_with_key.as_str(), args.max_response_bytes, args.cycles) {
+    let w3 = match ICHttp::new(url_with_key.as_str(), args.max_response_bytes, None) {
         Ok(v) => { Web3::new(v) },
         Err(e) => { return Err(e.to_string()) },
     };
 
-    let res = w3.json_rpc_call(args.body.as_str()).await.map_err(|e| format!("{}", e))?;
+    let cycles_before = ic_cdk::api::canister_balance128();
+    let call_res = w3.json_rpc_call(args.body.as_str()).await;
+    let cycles_after = ic_cdk::api::canister_balance128();
 
+    // add 0.001T cycles as buffer
+    let cycles_charged = ic_cdk::api::call::msg_cycles_accept128(cycles_before - cycles_after + 1_000_000_000u128);
+    ic_cdk::println!("cycles charged: {}", cycles_charged);
+    
+    let res = call_res.map_err(|e| format!("{}", e))?;
     ic_cdk::println!("result: {}", res);
 
     Ok(format!("{}", res))


### PR DESCRIPTION
- must pass the default max 0.5T cycles
- calculate the actual cycles consumed when rpc call
- the rest of cycles will be refunded