### PR TITLE
Remove old comment in example.rs

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -12,7 +12,6 @@ use ic_web3::{
     types::{Address, TransactionParameters, BlockId, BlockNumber},
 };
 
-// goerli testnet rpc url
 const URL: &str = "https://ethereum.publicnode.com";
 const CHAIN_ID: u64 = 1;
 const KEY_NAME: &str = "dfx_test_key";


### PR DESCRIPTION
 remove goerli testnet comment as the example uses https://ethereum.publicnode.com now.